### PR TITLE
refactor(next-adapter): loosen peer dependency versions

### DIFF
--- a/packages/next-adapter/package.json
+++ b/packages/next-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/next-adapter",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "author": "Expo <support@expo.dev>",
   "description": "Adapter for using Next.js to bundle Expo web projects",
   "keywords": [
@@ -39,10 +39,10 @@
     "expo-module-scripts": "^3.4.0"
   },
   "peerDependencies": {
-    "expo": "^46",
-    "next": "^13",
-    "react": "^18",
-    "react-native-web": "~0.18.0",
+    "expo": ">=46",
+    "next": ">=13",
+    "react": ">=18",
+    "react-native-web": ">=0.18.0",
     "webpack": "^4.46.0 || ^5.74.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Fixes #21
Fixes #11 
Fixes #9 
Fixes #8

# Why

This may break the integration in the future, but does remove the hard limitation on possible later versions. The Next adapter is not an actively maintained library and likely won't receive future updates.

# How

- Added `>=` version constraints

# Test Plan

- See if tests passes
- See if `bun create expo ./test-next --example with-nextjs` works
