### PR TITLE
chore(webpack): sync latest version from npm

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/webpack-config",
-  "version": "18.1.3",
+  "version": "19.0.0",
   "author": "Expo <support@expo.dev>",
   "description": "A Webpack configuration used to bundle Expo websites with Expo CLI.",
   "license": "MIT",


### PR DESCRIPTION
# Why

`18.1.3` is actually `19.0.0` and should not have been published.

# How

Synced version from npm, tested through a diff of `18.1.3` to `19.0.0`.

![image](https://github.com/expo/expo-webpack-integrations/assets/1203991/fc3a2d99-adbd-4016-841b-f7642b916f82)

# Test Plan

TBD