### PR TITLE
fix(webpack-config): loosen peer dependency versions

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -88,7 +88,7 @@
     "serve": "^11.1.0"
   },
   "peerDependencies": {
-    "expo": "^49.0.7"
+    "expo": ">=49.0.7"
   },
   "engines": {
     "node": ">=12"

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -88,7 +88,7 @@
     "serve": "^11.1.0"
   },
   "peerDependencies": {
-    "expo": ">=49.0.7"
+    "expo": "^49.0.7 || ^50.0.0-0"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
# Why

This allows npm to install `@expo/webpack-config@19` on a SDK 50 project, even though it's currently in maintenance mode.

I tested this in a separate blank project, seems to work fine.

> ~~⚠️ Apparently, we have some issues with the `x.x.x-preview.x` versions. npm won't allow `50.0.0-preview.11` when setting version constraint to `>=49.0.7`, which seems weird to me as `50.0.0-preview.11` is in-fact higher than `49.0.7`.~~
> ℹ️ This is now resolved by using `^50.0.0-0` to force-allow prereleases as peer dependency, [see this thread](https://stackoverflow.com/a/73572527)

# How

- Loosened peer dependency constraint
- Tested it in blank test project

# Test Plan

> ℹ️ Test this change with a tarball, not with the `file:...` option as that doesn't install or validate the peer dependencies properly with npm.

Create a test build for `@expo/webpack-config`
- `$ git clone <this repo>`
- `$ cd <this repo>`
- `$ yarn && yarn build`
- `$ cd ./packages/webpack-config`
- `$ npm pack`

Create a test project
- `$ npm create expo -- "./test-webpack" --template blank@beta`
- `$ cd ./test-webpack`
- Copy over the `*.tar.gz` file from `<this repo>/packages/webpack-config/*.tar.gz`
- Add `"@expo/webpack-config": "./*.tar.gz"` to **package.json** (use exact file name of the tar file)
- `$ npm install`
- `$ npm run web`
  - Install the missing `react-native-web` and `react-dom` packages
- `$ npm run web`
  - This should work fine.  
